### PR TITLE
#1: display stats every second instead of every 2s

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ mod writer;
   # Receive \"Hello World\" on eth1
   mnc eth1:239.1.1.1
 
-  # Receive and display statistics every 2 seconds
+  # Receive and display statistics every second
   mnc 239.1.1.1 -s
 
   # Display a hex dump of the first packet received
@@ -87,7 +87,7 @@ struct Args {
     #[arg(
         short = 's',
         long = "statistics",
-        help = "Display statistics every 2 seconds"
+        help = "Display statistics every second"
     )]
     stats: bool,
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -30,7 +30,7 @@ pub fn spawn(config: ReaderConfig) -> JoinHandle<Result<()>> {
         run_reader(&config)
             .inspect(|_| log::debug!("reader exited"))
             .inspect_err(|e| {
-                log::error!("{e:?}");
+                log::debug!("{e:?}");
                 config.shared_state.signal_exit()
             })
     })

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -10,8 +10,8 @@ use crate::{
     sdds, vita49,
 };
 
-// We only need to print every 2 seconds.
-const STATISTICS_DELAY_SECS: u64 = 2;
+// Print every second.
+const STATISTICS_DELAY_SECS: u64 = 1;
 
 pub struct StatisticsConfig {
     pub channels: (Receiver<Packets>, Sender<Packets>),
@@ -23,7 +23,7 @@ pub fn spawn(config: StatisticsConfig) -> JoinHandle<Result<()>> {
         run_statistics(&config)
             .inspect(|_| log::debug!("statistics exited"))
             .inspect_err(|e| {
-                log::error!("{e:?}");
+                log::debug!("{e:?}");
                 config.shared_state.signal_exit()
             })
     })

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -33,7 +33,7 @@ pub fn spawn(config: WriterConfig) -> JoinHandle<Result<()>> {
         run_writer(&config)
             .inspect(|_| log::debug!("writer exited"))
             .inspect_err(|e| {
-                log::error!("{e:?}");
+                log::debug!("{e:?}");
                 config.shared_state.signal_exit()
             })
     })


### PR DESCRIPTION
- Default stats every 1s instead of every 2s.
- Set exit logs to debug